### PR TITLE
feat: Intl API build

### DIFF
--- a/build-engine.sh
+++ b/build-engine.sh
@@ -21,7 +21,6 @@ ac_add_options --enable-project=js
 ac_add_options --enable-application=js
 ac_add_options --target=wasm32-unknown-wasi
 ac_add_options --without-system-zlib
-ac_add_options --without-intl-api
 ac_add_options --disable-jit
 ac_add_options --disable-shared-js
 ac_add_options --disable-shared-memory
@@ -126,9 +125,9 @@ cd "$working_dir"
 # Build SpiderMonkey for WASI
 MOZCONFIG="${mozconfig}" \
 MOZ_FETCHES_DIR=~/.mozbuild \
-CC=~/.mozbuild/clang/bin/clang \
-CXX=~/.mozbuild/clang/bin/clang++ \
-AR=~/.mozbuild/clang/bin/llvm-ar \
+CC=~/Projects/llvm-project/build/bin/clang \
+CXX=~/Projects/llvm-project/build/bin/clang++ \
+AR=~/Projects/llvm-project/build/bin/llvm-ar \
   python3 "${working_dir}/gecko-dev/mach" \
   --no-interactive \
     build


### PR DESCRIPTION
I just ran a full build of LLVM from trunk, then provided the paths to that LLVM version in the build script per the edits here, and then did some sysroot copy and pasting, and can confirm that Spidermonkey + Internationalization does build correctly!

This is certainly not landable but I wanted to post it up since it's the first time we've got this to work.

Steps to land include:
* Use a separate LLVM build as part of the build process
* Properly set up the sysroot in `build/lib/clang/20/lib/wasm32-unknown-wasi` or otherwise
* Set this up as a separate build to the main build without internationalization
* Update CI to perform both builds and to release both builds

Finally we could update StarlingMonkey to make this build an option and fully support internationalization.
